### PR TITLE
try using libc::setgroups for macOS

### DIFF
--- a/src/bin/http301d.rs
+++ b/src/bin/http301d.rs
@@ -249,6 +249,16 @@ fn drop_privs(log: &slog::Logger, args: &CommonArgs) -> Result<(), ServeError> {
     }
     if let Some(gid) = args.gid {
         nix::unistd::setgid(gid)?;
+
+        #[cfg(target_os = "macos")]
+        unsafe {
+            if libc::setgroups(1, &gid.as_raw()) != 0 {
+                eprintln!("Error with libc::setgroups");
+                std::process::exit(1);
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
         nix::unistd::setgroups(&[gid])?;
     }
     if let Some(uid) = args.uid {

--- a/src/bin/httpd2.rs
+++ b/src/bin/httpd2.rs
@@ -298,6 +298,16 @@ fn drop_privs(log: &slog::Logger, args: &CommonArgs) -> Result<(), ServeError> {
     }
     if let Some(gid) = args.gid {
         nix::unistd::setgid(gid)?;
+
+        #[cfg(target_os = "macos")]
+        unsafe {
+            if libc::setgroups(1, &gid.as_raw()) != 0 {
+                eprintln!("Error with libc::setgroups");
+                std::process::exit(1);
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
         nix::unistd::setgroups(&[gid])?;
     }
     if let Some(uid) = args.uid {


### PR DESCRIPTION
This is a draft because

a. I only have a cursory understanding of groups and dropping privileges
b. I never have called libc directly before
c. hard-coded the length of &gid.as_raw() to be 1, need to read what length is actually supposed to be (with u32, is length 4? 1? machine-dependent?)
d. raw pointer reference might be incorrect (instead of referring to memory address of the u32, it takes the group as the address)

but, at least `cargo build` works on macos and i was able to run `/target/release/httpd2 --upgrade .` in the source directory and things just worked.